### PR TITLE
Phase 2: GitHub Data Layer

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ When a feature (issue) is complete:
 
 ## GitHub Repository
 
-`alexAtEnaimco/PR-Demo`
+`enaimco/PR-Demo`
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Interface     →  FastAPI routes, HTMX templates
 
 ```bash
 # Clone and install dependencies
-git clone <repo-url>
+git clone https://github.com/enaimco/PR-Demo.git
 cd pr-demo
 pip install -e ".[dev]"
 

--- a/docs/adr/002-graphql-search-api.md
+++ b/docs/adr/002-graphql-search-api.md
@@ -1,0 +1,31 @@
+# ADR 002: Use GitHub GraphQL Search API for PR fetching
+
+## Status
+
+Accepted
+
+## Context
+
+We need to fetch all open pull requests for a GitHub organisation. Two approaches exist:
+
+1. **Per-repo traversal:** List all org repos, then query each repo's open PRs in parallel.
+2. **GraphQL search API:** Single paginated query using `org:<org> is:pr is:open`.
+
+## Decision
+
+Use the GraphQL search API (`search` query type).
+
+## Rationale
+
+- **Fewer round trips.** One paginated query vs. potentially hundreds of per-repo queries.
+- **Simpler code.** No need to manage parallel requests, rate limiting across repos, or repo-level pagination.
+- **All fields in one request.** `additions`, `deletions`, `changedFiles`, `commits.totalCount`, and `reviewThreads.totalCount` are all available on the `PullRequest` fragment.
+
+## Trade-offs
+
+- The search API has a **1,000 result limit**. Organisations with more than 1,000 open PRs would need the per-repo approach.
+- For the current use case (internal dashboards for typical orgs), this limit is acceptable.
+
+## Consequences
+
+- If the 1,000-result cap becomes a problem, we will need to refactor `GitHubGraphQLClient` to use per-repo traversal. The `GitHubPort` interface will not change — only the infrastructure implementation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -17,13 +17,18 @@ Pure Python. No I/O, no framework imports.
 
 | Component | Purpose |
 |-----------|---------|
-| `ports.py` | `SessionPort` abstract interface |
+| `ports.py` | `SessionPort` and `GitHubPort` abstract interfaces |
+| `pr.py` | `PRData` frozen dataclass, `AgeBracket` enum, age threshold constants |
+| `pr_age.py` | `classify_age()` — pure age bracket classification |
+| `pr_complexity.py` | `compute_complexity_score()` — weighted log-scaled scoring |
 
 ### Application — `src/application/`
 
 Orchestrates domain logic. Depends only on `domain/`.
 
-_Phase 1: empty. Use cases will be added in Phase 2._
+| Component | Purpose |
+|-----------|---------|
+| `fetch_org_pull_requests.py` | `FetchOrgPullRequestsUseCase` — fetches PRs via `GitHubPort`, classifies age and complexity |
 
 ### Infrastructure — `src/infrastructure/`
 
@@ -33,6 +38,7 @@ Implements the abstract ports defined in `domain/`.
 |-----------|---------|
 | `session.py` | `StarletteSessionAdapter` — wraps `request.session` |
 | `oauth.py` | `GitHubOAuthAdapter` — composes `authlib` OAuth client |
+| `github_client.py` | `GitHubGraphQLClient` — implements `GitHubPort` via GraphQL search API |
 
 ### Interface — `src/interface/`
 
@@ -40,9 +46,10 @@ FastAPI routers and Jinja2 templates. The only layer that imports from `infrastr
 
 | Component | Purpose |
 |-----------|---------|
-| `dependencies.py` | `get_session()` FastAPI dependency — single infra import point |
+| `dependencies.py` | `get_session()` and `get_fetch_org_pull_requests_use_case()` FastAPI dependencies |
 | `routers/auth.py` | `/login`, `/auth/callback`, `/logout` |
 | `routers/dashboard.py` | `/` — protected route |
+| `routers/pull_requests.py` | `GET /api/prs?org=<org>` — classified PR data as JSON |
 
 ## Composition Root
 

--- a/main.py
+++ b/main.py
@@ -26,7 +26,36 @@ def create_app() -> FastAPI:
     client_id = _require_env("GITHUB_CLIENT_ID")
     client_secret = _require_env("GITHUB_CLIENT_SECRET")
 
-    app = FastAPI(title="PR Dashboard", version="0.1.0")
+    app = FastAPI(
+        title="PR Dashboard",
+        version="0.1.0",
+        swagger_ui_init_oauth={},
+        openapi_tags=[{"name": "pull-requests"}],
+    )
+
+    # Register Bearer auth in OpenAPI so Swagger UI shows the Authorize button.
+    from fastapi.openapi.utils import get_openapi
+
+    def custom_openapi() -> dict:
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            routes=app.routes,
+        )
+        schema["components"]["securitySchemes"] = {
+            "BearerAuth": {
+                "type": "http",
+                "scheme": "bearer",
+                "description": "Paste your GitHub access token (shown on the dashboard).",
+            }
+        }
+        schema["security"] = [{"BearerAuth": []}]
+        app.openapi_schema = schema
+        return schema
+
+    app.openapi = custom_openapi
 
     # SessionMiddleware must be registered before any route that uses the session.
     app.add_middleware(SessionMiddleware, secret_key=session_secret)

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI
 from starlette.middleware.sessions import SessionMiddleware
 
 from src.infrastructure.oauth import GitHubOAuthAdapter
-from src.interface.routers import dashboard
+from src.interface.routers import dashboard, pull_requests
 from src.interface.routers.auth import build_auth_router
 
 load_dotenv()
@@ -38,6 +38,7 @@ def create_app() -> FastAPI:
 
     app.include_router(build_auth_router(oauth_adapter))
     app.include_router(dashboard.router)
+    app.include_router(pull_requests.router)
 
     return app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-asyncio>=0.23.0",
     "httpx>=0.27.0",
+    "respx>=0.21.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/application/fetch_org_pull_requests.py
+++ b/src/application/fetch_org_pull_requests.py
@@ -1,0 +1,63 @@
+"""Use case: fetch and classify open pull requests for an organisation."""
+
+from datetime import datetime, timezone
+from typing import Any
+
+from src.domain.ports import GitHubPort
+from src.domain.pr import PRData
+from src.domain.pr_age import classify_age
+from src.domain.pr_complexity import compute_complexity_score
+
+
+def _parse_created_at(raw: str) -> datetime:
+    """Parse an ISO-8601 timestamp into a timezone-aware datetime."""
+    return datetime.fromisoformat(raw.replace("Z", "+00:00"))
+
+
+def _build_pr_data(raw: dict[str, Any], now: datetime) -> PRData:
+    """Transform a raw PR dict into a classified PRData entity."""
+    created_at = _parse_created_at(raw["created_at"])
+    return PRData(
+        node_id=raw["node_id"],
+        title=raw["title"],
+        url=raw["url"],
+        author=raw["author"],
+        created_at=created_at,
+        is_draft=raw["is_draft"],
+        additions=raw["additions"],
+        deletions=raw["deletions"],
+        changed_files=raw["changed_files"],
+        commit_count=raw["commit_count"],
+        review_thread_count=raw["review_thread_count"],
+        age_bracket=classify_age(created_at, now),
+        complexity_score=compute_complexity_score(
+            additions=raw["additions"],
+            deletions=raw["deletions"],
+            changed_files=raw["changed_files"],
+            commit_count=raw["commit_count"],
+            review_thread_count=raw["review_thread_count"],
+        ),
+    )
+
+
+class FetchOrgPullRequestsUseCase:
+    """Orchestrates fetching PRs from GitHub and applying domain classification."""
+
+    def __init__(self, github_port: GitHubPort) -> None:
+        self._github_port = github_port
+
+    async def execute(
+        self,
+        organization: str,
+        now: datetime | None = None,
+    ) -> list[PRData]:
+        now = now or datetime.now(timezone.utc)
+        raw_pull_requests = await self._github_port.fetch_open_pull_requests(
+            organization
+        )
+        classified = [
+            _build_pr_data(raw, now) for raw in raw_pull_requests
+        ]
+        return sorted(
+            classified, key=lambda pr: pr.complexity_score, reverse=True
+        )

--- a/src/domain/ports.py
+++ b/src/domain/ports.py
@@ -8,6 +8,16 @@ from abc import ABC, abstractmethod
 from typing import Any
 
 
+class GitHubPort(ABC):
+    """Abstract interface for fetching pull request data from GitHub."""
+
+    @abstractmethod
+    async def fetch_open_pull_requests(
+        self, organization: str
+    ) -> list[dict[str, Any]]:
+        """Return raw PR data dicts for all open PRs in the given org."""
+
+
 class SessionPort(ABC):
     """Abstract session contract used by the application and interface layers."""
 

--- a/src/domain/pr.py
+++ b/src/domain/pr.py
@@ -1,0 +1,39 @@
+"""Domain entities for pull request data."""
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+FRESH_THRESHOLD_DAYS = 1
+RECENT_THRESHOLD_DAYS = 3
+AGING_THRESHOLD_DAYS = 7
+STALE_THRESHOLD_DAYS = 14
+
+
+class AgeBracket(Enum):
+    """Classification of a pull request's age."""
+
+    FRESH = "fresh"
+    RECENT = "recent"
+    AGING = "aging"
+    STALE = "stale"
+    ANCIENT = "ancient"
+
+
+@dataclass(frozen=True)
+class PRData:
+    """Immutable value object representing a classified pull request."""
+
+    node_id: str
+    title: str
+    url: str
+    author: str
+    created_at: datetime
+    is_draft: bool
+    additions: int
+    deletions: int
+    changed_files: int
+    commit_count: int
+    review_thread_count: int
+    age_bracket: AgeBracket
+    complexity_score: float

--- a/src/domain/pr_age.py
+++ b/src/domain/pr_age.py
@@ -1,0 +1,29 @@
+"""Pure age classification logic for pull requests."""
+
+from datetime import datetime
+
+from src.domain.pr import (
+    AGING_THRESHOLD_DAYS,
+    FRESH_THRESHOLD_DAYS,
+    RECENT_THRESHOLD_DAYS,
+    STALE_THRESHOLD_DAYS,
+    AgeBracket,
+)
+
+
+def classify_age(created_at: datetime, now: datetime) -> AgeBracket:
+    """Classify a pull request into an age bracket.
+
+    Both timestamps must be timezone-aware or both naive.
+    """
+    elapsed_days = (now - created_at).total_seconds() / 86400
+
+    if elapsed_days < FRESH_THRESHOLD_DAYS:
+        return AgeBracket.FRESH
+    if elapsed_days < RECENT_THRESHOLD_DAYS:
+        return AgeBracket.RECENT
+    if elapsed_days < AGING_THRESHOLD_DAYS:
+        return AgeBracket.AGING
+    if elapsed_days < STALE_THRESHOLD_DAYS:
+        return AgeBracket.STALE
+    return AgeBracket.ANCIENT

--- a/src/domain/pr_complexity.py
+++ b/src/domain/pr_complexity.py
@@ -1,0 +1,35 @@
+"""Pure complexity scoring logic for pull requests."""
+
+import math
+
+ADDITIONS_WEIGHT = 0.3
+DELETIONS_WEIGHT = 0.2
+CHANGED_FILES_WEIGHT = 0.25
+COMMITS_WEIGHT = 0.15
+REVIEW_THREADS_WEIGHT = 0.1
+
+MAX_SCORE = 100.0
+NORMALIZATION_DIVISOR = 10.0
+
+
+def compute_complexity_score(
+    additions: int,
+    deletions: int,
+    changed_files: int,
+    commit_count: int,
+    review_thread_count: int,
+) -> float:
+    """Compute a 0–100 complexity score from PR signals.
+
+    Uses log-scaled weighted sum to prevent extreme outliers
+    from dominating the score.
+    """
+    raw = (
+        ADDITIONS_WEIGHT * math.log1p(additions)
+        + DELETIONS_WEIGHT * math.log1p(deletions)
+        + CHANGED_FILES_WEIGHT * math.log1p(changed_files)
+        + COMMITS_WEIGHT * math.log1p(commit_count)
+        + REVIEW_THREADS_WEIGHT * math.log1p(review_thread_count)
+    )
+    normalized = (raw / NORMALIZATION_DIVISOR) * MAX_SCORE
+    return round(min(normalized, MAX_SCORE), 1)

--- a/src/infrastructure/github_client.py
+++ b/src/infrastructure/github_client.py
@@ -1,0 +1,123 @@
+"""GitHub GraphQL client implementing GitHubPort."""
+
+import re
+import time
+from typing import Any
+
+import httpx
+
+from src.domain.ports import GitHubPort
+
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+PAGE_SIZE = 50
+CACHE_TTL_SECONDS = 60
+
+OPEN_PRS_QUERY = """
+query($search_query: String!, $cursor: String) {
+  search(query: $search_query, type: ISSUE, first: 50, after: $cursor) {
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+    nodes {
+      ... on PullRequest {
+        id
+        title
+        url
+        author { login }
+        createdAt
+        isDraft
+        additions
+        deletions
+        changedFiles
+        commits { totalCount }
+        reviewThreads { totalCount }
+      }
+    }
+  }
+}
+"""
+
+ORG_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9\-]+$")
+
+
+def _validate_organization(organization: str) -> None:
+    """Reject org names that could alter the GraphQL search string."""
+    if not ORG_NAME_PATTERN.match(organization):
+        raise ValueError(f"Invalid organization name: {organization!r}")
+
+
+def _parse_pull_request_node(node: dict[str, Any]) -> dict[str, Any]:
+    """Transform a GraphQL PR node into the flat dict contract."""
+    return {
+        "node_id": node["id"],
+        "title": node["title"],
+        "url": node["url"],
+        "author": (node.get("author") or {}).get("login", "ghost"),
+        "created_at": node["createdAt"],
+        "is_draft": node["isDraft"],
+        "additions": node["additions"],
+        "deletions": node["deletions"],
+        "changed_files": node["changedFiles"],
+        "commit_count": node["commits"]["totalCount"],
+        "review_thread_count": node["reviewThreads"]["totalCount"],
+    }
+
+
+class GitHubGraphQLClient(GitHubPort):
+    """Fetches open pull requests from GitHub using the GraphQL search API."""
+
+    def __init__(self, access_token: str) -> None:
+        self._access_token = access_token
+        self._cache: dict[str, tuple[float, list[dict[str, Any]]]] = {}
+
+    async def fetch_open_pull_requests(
+        self, organization: str
+    ) -> list[dict[str, Any]]:
+        _validate_organization(organization)
+
+        cached = self._cache.get(organization)
+        if cached and (time.monotonic() - cached[0]) < CACHE_TTL_SECONDS:
+            return cached[1]
+
+        pull_requests = await self._fetch_all_pages(organization)
+        self._cache[organization] = (time.monotonic(), pull_requests)
+        return pull_requests
+
+    async def _fetch_all_pages(
+        self, organization: str
+    ) -> list[dict[str, Any]]:
+        pull_requests: list[dict[str, Any]] = []
+        cursor: str | None = None
+        search_query = f"org:{organization} is:pr is:open"
+
+        async with httpx.AsyncClient() as client:
+            while True:
+                response = await client.post(
+                    GITHUB_GRAPHQL_URL,
+                    json={
+                        "query": OPEN_PRS_QUERY,
+                        "variables": {
+                            "search_query": search_query,
+                            "cursor": cursor,
+                        },
+                    },
+                    headers={
+                        "Authorization": f"Bearer {self._access_token}",
+                        "Content-Type": "application/json",
+                    },
+                )
+                response.raise_for_status()
+                data = response.json()
+
+                search_result = data["data"]["search"]
+                for node in search_result["nodes"]:
+                    if node:
+                        pull_requests.append(_parse_pull_request_node(node))
+
+                page_info = search_result["pageInfo"]
+                if not page_info["hasNextPage"]:
+                    break
+                cursor = page_info["endCursor"]
+
+        return pull_requests

--- a/src/infrastructure/github_client.py
+++ b/src/infrastructure/github_client.py
@@ -8,6 +8,8 @@ import httpx
 
 from src.domain.ports import GitHubPort
 
+GITHUB_UNAUTHORIZED_STATUS = 401
+
 GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 PAGE_SIZE = 50
 CACHE_TTL_SECONDS = 60
@@ -107,8 +109,15 @@ class GitHubGraphQLClient(GitHubPort):
                         "Content-Type": "application/json",
                     },
                 )
+                if response.status_code == GITHUB_UNAUTHORIZED_STATUS:
+                    raise PermissionError("GitHub token is invalid or expired")
                 response.raise_for_status()
                 data = response.json()
+
+                if "errors" in data:
+                    raise PermissionError(
+                        data["errors"][0].get("message", "GitHub API error")
+                    )
 
                 search_result = data["data"]["search"]
                 for node in search_result["nodes"]:

--- a/src/infrastructure/session.py
+++ b/src/infrastructure/session.py
@@ -7,6 +7,7 @@ from starlette.requests import Request
 from src.domain.ports import SessionPort
 
 GITHUB_ACCESS_TOKEN_KEY = "github_access_token"
+GITHUB_USERNAME_KEY = "github_username"
 
 
 class StarletteSessionAdapter(SessionPort):

--- a/src/interface/dependencies.py
+++ b/src/interface/dependencies.py
@@ -1,11 +1,25 @@
 """FastAPI dependency injection helpers for the interface layer."""
 
-from fastapi import Request
+from fastapi import HTTPException, Request
 
+from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.ports import SessionPort
-from src.infrastructure.session import StarletteSessionAdapter
+from src.infrastructure.github_client import GitHubGraphQLClient
+from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY, StarletteSessionAdapter
 
 
 def get_session(request: Request) -> SessionPort:
     """Provide a SessionPort backed by Starlette's session middleware."""
     return StarletteSessionAdapter(request)
+
+
+def get_fetch_org_pull_requests_use_case(
+    request: Request,
+) -> FetchOrgPullRequestsUseCase:
+    """Build a FetchOrgPullRequestsUseCase wired to the current user's token."""
+    session = StarletteSessionAdapter(request)
+    access_token = session.get(GITHUB_ACCESS_TOKEN_KEY)
+    if not access_token:
+        raise HTTPException(status_code=401, detail="Not authenticated")
+    github_client = GitHubGraphQLClient(access_token=access_token)
+    return FetchOrgPullRequestsUseCase(github_port=github_client)

--- a/src/interface/dependencies.py
+++ b/src/interface/dependencies.py
@@ -1,14 +1,11 @@
 """FastAPI dependency injection helpers for the interface layer."""
 
 from fastapi import HTTPException, Request
-from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.ports import SessionPort
 from src.infrastructure.github_client import GitHubGraphQLClient
 from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY, StarletteSessionAdapter
-
-bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def get_session(request: Request) -> SessionPort:
@@ -32,7 +29,6 @@ def _extract_access_token(request: Request) -> str:
 
 def get_fetch_org_pull_requests_use_case(
     request: Request,
-    _credentials: HTTPAuthorizationCredentials | None = None,
 ) -> FetchOrgPullRequestsUseCase:
     """Build a FetchOrgPullRequestsUseCase wired to the current user's token."""
     access_token = _extract_access_token(request)

--- a/src/interface/dependencies.py
+++ b/src/interface/dependencies.py
@@ -24,6 +24,11 @@ def _extract_bearer_token(request: Request) -> str:
     raise HTTPException(status_code=401, detail="Not authenticated")
 
 
+def require_bearer_token(request: Request) -> str:
+    """Router-level dependency that enforces Bearer auth on all API routes."""
+    return _extract_bearer_token(request)
+
+
 def get_fetch_org_pull_requests_use_case(
     request: Request,
 ) -> FetchOrgPullRequestsUseCase:

--- a/src/interface/dependencies.py
+++ b/src/interface/dependencies.py
@@ -1,11 +1,14 @@
 """FastAPI dependency injection helpers for the interface layer."""
 
 from fastapi import HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.ports import SessionPort
 from src.infrastructure.github_client import GitHubGraphQLClient
 from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY, StarletteSessionAdapter
+
+bearer_scheme = HTTPBearer(auto_error=False)
 
 
 def get_session(request: Request) -> SessionPort:
@@ -13,13 +16,25 @@ def get_session(request: Request) -> SessionPort:
     return StarletteSessionAdapter(request)
 
 
+def _extract_access_token(request: Request) -> str:
+    """Extract token from Authorization header or session cookie."""
+    auth_header = request.headers.get("authorization", "")
+    if auth_header.lower().startswith("bearer "):
+        return auth_header[7:].strip()
+
+    session = StarletteSessionAdapter(request)
+    token = session.get(GITHUB_ACCESS_TOKEN_KEY)
+    if token:
+        return token
+
+    raise HTTPException(status_code=401, detail="Not authenticated")
+
+
 def get_fetch_org_pull_requests_use_case(
     request: Request,
+    _credentials: HTTPAuthorizationCredentials | None = None,
 ) -> FetchOrgPullRequestsUseCase:
     """Build a FetchOrgPullRequestsUseCase wired to the current user's token."""
-    session = StarletteSessionAdapter(request)
-    access_token = session.get(GITHUB_ACCESS_TOKEN_KEY)
-    if not access_token:
-        raise HTTPException(status_code=401, detail="Not authenticated")
+    access_token = _extract_access_token(request)
     github_client = GitHubGraphQLClient(access_token=access_token)
     return FetchOrgPullRequestsUseCase(github_port=github_client)

--- a/src/interface/dependencies.py
+++ b/src/interface/dependencies.py
@@ -13,16 +13,13 @@ def get_session(request: Request) -> SessionPort:
     return StarletteSessionAdapter(request)
 
 
-def _extract_access_token(request: Request) -> str:
-    """Extract token from Authorization header or session cookie."""
+def _extract_bearer_token(request: Request) -> str:
+    """Extract token strictly from the Authorization: Bearer header."""
     auth_header = request.headers.get("authorization", "")
     if auth_header.lower().startswith("bearer "):
-        return auth_header[7:].strip()
-
-    session = StarletteSessionAdapter(request)
-    token = session.get(GITHUB_ACCESS_TOKEN_KEY)
-    if token:
-        return token
+        token = auth_header[7:].strip()
+        if token:
+            return token
 
     raise HTTPException(status_code=401, detail="Not authenticated")
 
@@ -31,6 +28,6 @@ def get_fetch_org_pull_requests_use_case(
     request: Request,
 ) -> FetchOrgPullRequestsUseCase:
     """Build a FetchOrgPullRequestsUseCase wired to the current user's token."""
-    access_token = _extract_access_token(request)
+    access_token = _extract_bearer_token(request)
     github_client = GitHubGraphQLClient(access_token=access_token)
     return FetchOrgPullRequestsUseCase(github_port=github_client)

--- a/src/interface/routers/auth.py
+++ b/src/interface/routers/auth.py
@@ -2,11 +2,16 @@
 
 from fastapi import APIRouter, Depends, Request
 from fastapi.responses import RedirectResponse
+from fastapi.templating import Jinja2Templates
 
 from src.domain.ports import SessionPort
+import httpx
+
 from src.infrastructure.oauth import GitHubOAuthAdapter, OAuthError
-from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY
+from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY, GITHUB_USERNAME_KEY
 from src.interface.dependencies import get_session
+
+templates = Jinja2Templates(directory="templates")
 
 
 def build_auth_router(oauth_adapter: GitHubOAuthAdapter) -> APIRouter:
@@ -14,7 +19,11 @@ def build_auth_router(oauth_adapter: GitHubOAuthAdapter) -> APIRouter:
     router = APIRouter()
 
     @router.get("/login")
-    async def login(request: Request) -> RedirectResponse:
+    async def login(request: Request) -> object:
+        return templates.TemplateResponse("login.html", {"request": request})
+
+    @router.get("/login/oauth")
+    async def login_oauth(request: Request) -> RedirectResponse:
         redirect_uri = str(request.url_for("callback"))
         return await oauth_adapter.redirect_to_authorization(request, redirect_uri)
 
@@ -28,7 +37,17 @@ def build_auth_router(oauth_adapter: GitHubOAuthAdapter) -> APIRouter:
         except OAuthError:
             return RedirectResponse(url="/login")
 
-        session.set(GITHUB_ACCESS_TOKEN_KEY, token.get("access_token"))
+        access_token = token.get("access_token")
+        session.set(GITHUB_ACCESS_TOKEN_KEY, access_token)
+
+        async with httpx.AsyncClient() as client:
+            response = await client.get(
+                "https://api.github.com/user",
+                headers={"Authorization": f"Bearer {access_token}"},
+            )
+            if response.status_code == 200:
+                session.set(GITHUB_USERNAME_KEY, response.json().get("login"))
+
         return RedirectResponse(url="/")
 
     @router.get("/logout")

--- a/src/interface/routers/dashboard.py
+++ b/src/interface/routers/dashboard.py
@@ -5,7 +5,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from src.domain.ports import SessionPort
-from src.infrastructure.session import GITHUB_USERNAME_KEY
+from src.infrastructure.session import GITHUB_ACCESS_TOKEN_KEY, GITHUB_USERNAME_KEY
 from src.interface.dependencies import get_session
 
 router = APIRouter()
@@ -20,7 +20,12 @@ async def dashboard(
     if not session.is_authenticated():
         return RedirectResponse(url="/login")
     github_username = session.get(GITHUB_USERNAME_KEY)
+    access_token = session.get(GITHUB_ACCESS_TOKEN_KEY)
     return templates.TemplateResponse(
         "dashboard.html",
-        {"request": request, "github_username": github_username},
+        {
+            "request": request,
+            "github_username": github_username,
+            "access_token": access_token,
+        },
     )

--- a/src/interface/routers/dashboard.py
+++ b/src/interface/routers/dashboard.py
@@ -5,6 +5,7 @@ from fastapi.responses import RedirectResponse
 from fastapi.templating import Jinja2Templates
 
 from src.domain.ports import SessionPort
+from src.infrastructure.session import GITHUB_USERNAME_KEY
 from src.interface.dependencies import get_session
 
 router = APIRouter()
@@ -18,4 +19,8 @@ async def dashboard(
 ) -> object:
     if not session.is_authenticated():
         return RedirectResponse(url="/login")
-    return templates.TemplateResponse("dashboard.html", {"request": request})
+    github_username = session.get(GITHUB_USERNAME_KEY)
+    return templates.TemplateResponse(
+        "dashboard.html",
+        {"request": request, "github_username": github_username},
+    )

--- a/src/interface/routers/pull_requests.py
+++ b/src/interface/routers/pull_requests.py
@@ -1,0 +1,60 @@
+"""Pull request API routes."""
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
+from src.domain.pr import PRData
+from src.interface.dependencies import get_fetch_org_pull_requests_use_case
+
+router = APIRouter(prefix="/api", tags=["pull-requests"])
+
+
+class PullRequestResponse(BaseModel):
+    """Swagger-friendly response model for a classified pull request."""
+
+    node_id: str
+    title: str
+    url: str
+    author: str
+    created_at: datetime
+    is_draft: bool
+    additions: int
+    deletions: int
+    changed_files: int
+    commit_count: int
+    review_thread_count: int
+    age_bracket: str
+    complexity_score: float
+
+
+def _to_response(pr_data: PRData) -> PullRequestResponse:
+    return PullRequestResponse(
+        node_id=pr_data.node_id,
+        title=pr_data.title,
+        url=pr_data.url,
+        author=pr_data.author,
+        created_at=pr_data.created_at,
+        is_draft=pr_data.is_draft,
+        additions=pr_data.additions,
+        deletions=pr_data.deletions,
+        changed_files=pr_data.changed_files,
+        commit_count=pr_data.commit_count,
+        review_thread_count=pr_data.review_thread_count,
+        age_bracket=pr_data.age_bracket.value,
+        complexity_score=pr_data.complexity_score,
+    )
+
+
+@router.get("/prs", response_model=list[PullRequestResponse])
+async def list_organization_pull_requests(
+    org: str,
+    use_case: FetchOrgPullRequestsUseCase = Depends(
+        get_fetch_org_pull_requests_use_case
+    ),
+) -> list[PullRequestResponse]:
+    """Fetch and classify all open PRs for the given GitHub organisation."""
+    pull_requests = await use_case.execute(organization=org)
+    return [_to_response(pr) for pr in pull_requests]

--- a/src/interface/routers/pull_requests.py
+++ b/src/interface/routers/pull_requests.py
@@ -2,12 +2,12 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends, Security
+from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.pr import PRData
-from src.interface.dependencies import bearer_scheme, get_fetch_org_pull_requests_use_case
+from src.interface.dependencies import get_fetch_org_pull_requests_use_case
 
 router = APIRouter(prefix="/api", tags=["pull-requests"])
 
@@ -48,7 +48,7 @@ def _to_response(pr_data: PRData) -> PullRequestResponse:
     )
 
 
-@router.get("/prs", response_model=list[PullRequestResponse], dependencies=[Security(bearer_scheme)])
+@router.get("/prs", response_model=list[PullRequestResponse])
 async def list_organization_pull_requests(
     org: str,
     use_case: FetchOrgPullRequestsUseCase = Depends(

--- a/src/interface/routers/pull_requests.py
+++ b/src/interface/routers/pull_requests.py
@@ -2,12 +2,12 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Security
 from pydantic import BaseModel
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.pr import PRData
-from src.interface.dependencies import get_fetch_org_pull_requests_use_case
+from src.interface.dependencies import bearer_scheme, get_fetch_org_pull_requests_use_case
 
 router = APIRouter(prefix="/api", tags=["pull-requests"])
 
@@ -48,7 +48,7 @@ def _to_response(pr_data: PRData) -> PullRequestResponse:
     )
 
 
-@router.get("/prs", response_model=list[PullRequestResponse])
+@router.get("/prs", response_model=list[PullRequestResponse], dependencies=[Security(bearer_scheme)])
 async def list_organization_pull_requests(
     org: str,
     use_case: FetchOrgPullRequestsUseCase = Depends(

--- a/src/interface/routers/pull_requests.py
+++ b/src/interface/routers/pull_requests.py
@@ -7,9 +7,13 @@ from pydantic import BaseModel
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
 from src.domain.pr import PRData
-from src.interface.dependencies import get_fetch_org_pull_requests_use_case
+from src.interface.dependencies import get_fetch_org_pull_requests_use_case, require_bearer_token
 
-router = APIRouter(prefix="/api", tags=["pull-requests"])
+router = APIRouter(
+    prefix="/api",
+    tags=["pull-requests"],
+    dependencies=[Depends(require_bearer_token)],
+)
 
 
 class PullRequestResponse(BaseModel):

--- a/src/interface/routers/pull_requests.py
+++ b/src/interface/routers/pull_requests.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 
 from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
@@ -56,5 +56,8 @@ async def list_organization_pull_requests(
     ),
 ) -> list[PullRequestResponse]:
     """Fetch and classify all open PRs for the given GitHub organisation."""
-    pull_requests = await use_case.execute(organization=org)
+    try:
+        pull_requests = await use_case.execute(organization=org)
+    except PermissionError as exc:
+        raise HTTPException(status_code=401, detail=str(exc))
     return [_to_response(pr) for pr in pull_requests]

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -5,7 +5,7 @@
 {% block content %}
 <main>
     <h1>PR Dashboard</h1>
-    <p>You are authenticated.</p>
+    <p>Signed in as <strong>{{ github_username }}</strong></p>
     <p><em>Phase 1 stub — PR listing coming in Phase 2.</em></p>
     <a href="/logout">Sign out</a>
 </main>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -7,6 +7,11 @@
     <h1>PR Dashboard</h1>
     <p>Signed in as <strong>{{ github_username }}</strong></p>
     <p><em>Phase 1 stub — PR listing coming in Phase 2.</em></p>
+    <details>
+        <summary>API Token (dev)</summary>
+        <code style="word-break: break-all; user-select: all;">{{ access_token }}</code>
+    </details>
+    <br/>
     <a href="/logout">Sign out</a>
 </main>
 {% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -6,6 +6,6 @@
 <main>
     <h1>PR Dashboard</h1>
     <p>Sign in to view your organisation's open pull requests.</p>
-    <a href="/login">Sign in with GitHub</a>
+    <a href="/login/oauth">Sign in with GitHub</a>
 </main>
 {% endblock %}

--- a/tests/application/test_fetch_org_pull_requests.py
+++ b/tests/application/test_fetch_org_pull_requests.py
@@ -1,0 +1,84 @@
+"""Use case tests with a fake GitHubPort — no real HTTP."""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.application.fetch_org_pull_requests import FetchOrgPullRequestsUseCase
+from src.domain.ports import GitHubPort
+from src.domain.pr import AgeBracket
+
+NOW = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class FakeGitHubPort(GitHubPort):
+    """In-memory fake returning canned PR data."""
+
+    def __init__(self, pull_requests: list[dict[str, Any]]) -> None:
+        self._pull_requests = pull_requests
+
+    async def fetch_open_pull_requests(
+        self, organization: str
+    ) -> list[dict[str, Any]]:
+        return self._pull_requests
+
+
+def _make_raw_pr(
+    *,
+    title: str = "Fix bug",
+    created_at: str = "2026-03-25T06:00:00Z",
+    additions: int = 10,
+    deletions: int = 5,
+    changed_files: int = 2,
+    commit_count: int = 1,
+    review_thread_count: int = 0,
+) -> dict[str, Any]:
+    return {
+        "node_id": "PR_abc123",
+        "title": title,
+        "url": "https://github.com/org/repo/pull/1",
+        "author": "dev",
+        "created_at": created_at,
+        "is_draft": False,
+        "additions": additions,
+        "deletions": deletions,
+        "changed_files": changed_files,
+        "commit_count": commit_count,
+        "review_thread_count": review_thread_count,
+    }
+
+
+async def test_returns_classified_pull_requests() -> None:
+    six_hours_ago = (NOW - timedelta(hours=6)).isoformat()
+    ten_days_ago = (NOW - timedelta(days=10)).isoformat()
+
+    fake_port = FakeGitHubPort([
+        _make_raw_pr(title="Fresh PR", created_at=six_hours_ago),
+        _make_raw_pr(title="Stale PR", created_at=ten_days_ago),
+    ])
+    use_case = FetchOrgPullRequestsUseCase(github_port=fake_port)
+    result = await use_case.execute(organization="test-org", now=NOW)
+
+    assert len(result) == 2
+    brackets = {pr.title: pr.age_bracket for pr in result}
+    assert brackets["Fresh PR"] == AgeBracket.FRESH
+    assert brackets["Stale PR"] == AgeBracket.STALE
+
+
+async def test_empty_org_returns_empty_list() -> None:
+    fake_port = FakeGitHubPort([])
+    use_case = FetchOrgPullRequestsUseCase(github_port=fake_port)
+    result = await use_case.execute(organization="empty-org", now=NOW)
+    assert result == []
+
+
+async def test_results_sorted_by_complexity_descending() -> None:
+    fake_port = FakeGitHubPort([
+        _make_raw_pr(title="Small", additions=1, deletions=0, changed_files=1),
+        _make_raw_pr(title="Large", additions=5000, deletions=2000, changed_files=50, commit_count=30, review_thread_count=10),
+    ])
+    use_case = FetchOrgPullRequestsUseCase(github_port=fake_port)
+    result = await use_case.execute(organization="test-org", now=NOW)
+
+    assert result[0].title == "Large"
+    assert result[1].title == "Small"
+    assert result[0].complexity_score > result[1].complexity_score

--- a/tests/domain/test_pr_age.py
+++ b/tests/domain/test_pr_age.py
@@ -1,0 +1,57 @@
+"""Unit tests for age bracket classification — pure, no I/O."""
+
+from datetime import datetime, timedelta, timezone
+
+from src.domain.pr import AgeBracket
+from src.domain.pr_age import classify_age
+
+NOW = datetime(2026, 3, 25, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def test_fresh_under_one_day() -> None:
+    created = NOW - timedelta(hours=6)
+    assert classify_age(created, NOW) == AgeBracket.FRESH
+
+
+def test_recent_between_one_and_three_days() -> None:
+    created = NOW - timedelta(days=2)
+    assert classify_age(created, NOW) == AgeBracket.RECENT
+
+
+def test_aging_between_three_and_seven_days() -> None:
+    created = NOW - timedelta(days=5)
+    assert classify_age(created, NOW) == AgeBracket.AGING
+
+
+def test_stale_between_seven_and_fourteen_days() -> None:
+    created = NOW - timedelta(days=10)
+    assert classify_age(created, NOW) == AgeBracket.STALE
+
+
+def test_ancient_over_fourteen_days() -> None:
+    created = NOW - timedelta(days=20)
+    assert classify_age(created, NOW) == AgeBracket.ANCIENT
+
+
+def test_boundary_exactly_one_day() -> None:
+    created = NOW - timedelta(days=1)
+    assert classify_age(created, NOW) == AgeBracket.RECENT
+
+
+def test_boundary_exactly_three_days() -> None:
+    created = NOW - timedelta(days=3)
+    assert classify_age(created, NOW) == AgeBracket.AGING
+
+
+def test_boundary_exactly_seven_days() -> None:
+    created = NOW - timedelta(days=7)
+    assert classify_age(created, NOW) == AgeBracket.STALE
+
+
+def test_boundary_exactly_fourteen_days() -> None:
+    created = NOW - timedelta(days=14)
+    assert classify_age(created, NOW) == AgeBracket.ANCIENT
+
+
+def test_just_created() -> None:
+    assert classify_age(NOW, NOW) == AgeBracket.FRESH

--- a/tests/domain/test_pr_complexity.py
+++ b/tests/domain/test_pr_complexity.py
@@ -1,0 +1,64 @@
+"""Unit tests for complexity scoring — pure, no I/O."""
+
+from src.domain.pr_complexity import MAX_SCORE, compute_complexity_score
+
+
+def test_zero_signals_returns_zero() -> None:
+    score = compute_complexity_score(
+        additions=0,
+        deletions=0,
+        changed_files=0,
+        commit_count=0,
+        review_thread_count=0,
+    )
+    assert score == 0.0
+
+
+def test_small_pr_low_score() -> None:
+    score = compute_complexity_score(
+        additions=5,
+        deletions=2,
+        changed_files=1,
+        commit_count=1,
+        review_thread_count=0,
+    )
+    assert 0 < score < 30
+
+
+def test_large_pr_high_score() -> None:
+    score = compute_complexity_score(
+        additions=2000,
+        deletions=500,
+        changed_files=40,
+        commit_count=20,
+        review_thread_count=15,
+    )
+    assert score > 50
+
+
+def test_score_never_exceeds_max() -> None:
+    score = compute_complexity_score(
+        additions=100_000,
+        deletions=100_000,
+        changed_files=1000,
+        commit_count=500,
+        review_thread_count=200,
+    )
+    assert score <= MAX_SCORE
+
+
+def test_additions_increase_score() -> None:
+    baseline = compute_complexity_score(10, 0, 1, 1, 0)
+    higher = compute_complexity_score(1000, 0, 1, 1, 0)
+    assert higher > baseline
+
+
+def test_all_signals_contribute() -> None:
+    base = compute_complexity_score(10, 10, 5, 3, 2)
+    assert base > 0
+    # Each signal at zero should reduce score
+    assert compute_complexity_score(0, 10, 5, 3, 2) < base
+    assert compute_complexity_score(10, 0, 5, 3, 2) < base
+    assert compute_complexity_score(10, 10, 0, 3, 2) < base
+    assert compute_complexity_score(10, 10, 5, 0, 2) < base
+    assert compute_complexity_score(10, 10, 5, 3, 0) < base

--- a/tests/infrastructure/test_github_client.py
+++ b/tests/infrastructure/test_github_client.py
@@ -1,0 +1,104 @@
+"""Integration tests for GitHubGraphQLClient using respx to mock HTTP."""
+
+import pytest
+import respx
+from httpx import Response
+
+from src.infrastructure.github_client import GITHUB_GRAPHQL_URL, GitHubGraphQLClient
+
+
+def _graphql_response(nodes: list[dict], has_next: bool = False, cursor: str | None = None) -> dict:
+    return {
+        "data": {
+            "search": {
+                "pageInfo": {
+                    "hasNextPage": has_next,
+                    "endCursor": cursor,
+                },
+                "nodes": nodes,
+            }
+        }
+    }
+
+
+def _sample_pr_node(*, node_id: str = "PR_1", title: str = "Fix typo") -> dict:
+    return {
+        "id": node_id,
+        "title": title,
+        "url": "https://github.com/org/repo/pull/1",
+        "author": {"login": "dev"},
+        "createdAt": "2026-03-20T10:00:00Z",
+        "isDraft": False,
+        "additions": 10,
+        "deletions": 3,
+        "changedFiles": 2,
+        "commits": {"totalCount": 1},
+        "reviewThreads": {"totalCount": 0},
+    }
+
+
+@respx.mock
+async def test_fetch_parses_single_page() -> None:
+    respx.post(GITHUB_GRAPHQL_URL).mock(
+        return_value=Response(200, json=_graphql_response([_sample_pr_node()]))
+    )
+
+    client = GitHubGraphQLClient(access_token="fake-token")
+    result = await client.fetch_open_pull_requests("test-org")
+
+    assert len(result) == 1
+    assert result[0]["node_id"] == "PR_1"
+    assert result[0]["title"] == "Fix typo"
+    assert result[0]["author"] == "dev"
+    assert result[0]["commit_count"] == 1
+
+
+@respx.mock
+async def test_handles_pagination() -> None:
+    route = respx.post(GITHUB_GRAPHQL_URL)
+    route.side_effect = [
+        Response(200, json=_graphql_response(
+            [_sample_pr_node(node_id="PR_1")], has_next=True, cursor="cursor1"
+        )),
+        Response(200, json=_graphql_response(
+            [_sample_pr_node(node_id="PR_2", title="Second PR")]
+        )),
+    ]
+
+    client = GitHubGraphQLClient(access_token="fake-token")
+    result = await client.fetch_open_pull_requests("test-org")
+
+    assert len(result) == 2
+    assert result[0]["node_id"] == "PR_1"
+    assert result[1]["node_id"] == "PR_2"
+
+
+@respx.mock
+async def test_handles_empty_org() -> None:
+    respx.post(GITHUB_GRAPHQL_URL).mock(
+        return_value=Response(200, json=_graphql_response([]))
+    )
+
+    client = GitHubGraphQLClient(access_token="fake-token")
+    result = await client.fetch_open_pull_requests("empty-org")
+
+    assert result == []
+
+
+@respx.mock
+async def test_skips_null_nodes() -> None:
+    respx.post(GITHUB_GRAPHQL_URL).mock(
+        return_value=Response(200, json=_graphql_response([None, _sample_pr_node()]))
+    )
+
+    client = GitHubGraphQLClient(access_token="fake-token")
+    result = await client.fetch_open_pull_requests("test-org")
+
+    assert len(result) == 1
+
+
+def test_rejects_invalid_org_name() -> None:
+    client = GitHubGraphQLClient(access_token="fake-token")
+    with pytest.raises(ValueError, match="Invalid organization name"):
+        import asyncio
+        asyncio.run(client.fetch_open_pull_requests("org with spaces"))

--- a/tests/infrastructure/test_prs_api.py
+++ b/tests/infrastructure/test_prs_api.py
@@ -1,0 +1,19 @@
+"""Integration tests for the /api/prs endpoint."""
+
+from starlette.testclient import TestClient
+
+from main import create_app
+
+
+def test_prs_endpoint_requires_authentication() -> None:
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/prs", params={"org": "test-org"})
+    assert response.status_code == 401
+
+
+def test_prs_endpoint_without_org_still_requires_auth() -> None:
+    app = create_app()
+    client = TestClient(app)
+    response = client.get("/api/prs")
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary

Implements the GitHub data layer (Phase 2) with minor Phase 1 polish (login landing page, username display on dashboard).

**Phase 1 polish:**
- Login page now shows a landing template before redirecting to GitHub OAuth
- Dashboard displays the authenticated GitHub username
- Access token shown on dashboard for dev/Swagger testing

**Phase 2 — GitHub Data Layer:**
- Domain entities: `PRData` dataclass, `AgeBracket` enum (fresh/recent/aging/stale/ancient)
- Pure domain logic: `classify_age()` and `compute_complexity_score()` (log-scaled weighted formula)
- `GitHubPort` abstract interface with `GitHubGraphQLClient` implementation (GraphQL search API, pagination, 60s cache, org name validation)
- `FetchOrgPullRequestsUseCase` orchestrating fetch + classification
- `GET /api/prs?org=<org>` JSON endpoint with Pydantic response model
- Bearer token auth enforced at router level on all `/api/` routes
- OpenAPI/Swagger integration with Authorize button

Closes #2

## Architecture

All four onion layers implemented with strict dependency rules:
- **Domain:** `PRData`, `AgeBracket`, `GitHubPort`, `SessionPort`, pure classification functions
- **Application:** `FetchOrgPullRequestsUseCase`
- **Infrastructure:** `GitHubGraphQLClient`, `GitHubOAuthAdapter`, `StarletteSessionAdapter`
- **Interface:** Auth routes, dashboard route, `/api/prs` endpoint with router-level Bearer auth

## Testing

35 tests passing:
- Domain: age bracket boundaries, complexity scoring properties
- Application: use case with fake port
- Infrastructure: respx-mocked GraphQL client, API auth enforcement

## Test plan

- [ ] `pytest` — all 35 tests pass
- [ ] Start app, sign in via GitHub OAuth at `http://localhost:8000`
- [ ] Verify dashboard shows GitHub username
- [ ] Copy token from dashboard, authorize in Swagger at `/docs`
- [ ] Hit `GET /api/prs?org=enaimco` — returns classified PR JSON
- [ ] Verify `/api/prs` returns 401 without Bearer token (even if logged in via browser)

🤖 Generated with [Claude Code](https://claude.com/claude-code)